### PR TITLE
improve modifier only hotkeys

### DIFF
--- a/src/hotkey.cpp
+++ b/src/hotkey.cpp
@@ -18,6 +18,8 @@ extern hotkey Modifiers;
 extern long long ModifierTriggerTime;
 extern double ModifierTriggerTimeout;
 
+extern bool ModifierTriggerLast;
+
 internal inline void
 ClockGetTime(long long *Time)
 {
@@ -423,6 +425,7 @@ ModifierPressed(uint32_t Flag)
 {
     AddFlags(&Modifiers, Flag);
     ClockGetTime(&ModifierTriggerTime);
+    ModifierTriggerLast = true;
 }
 
 internal inline void
@@ -430,7 +433,8 @@ ModifierReleased(uint32_t Flag)
 {
     long long Time;
     ClockGetTime(&Time);
-    if(GetTimeDiff(Time, ModifierTriggerTime) < ModifierTriggerTimeout)
+    if(ModifierTriggerLast &&
+       (GetTimeDiff(Time, ModifierTriggerTime) < ModifierTriggerTimeout))
     {
         ExecuteModifierOnlyHotkey(Flag);
     }

--- a/src/khd.cpp
+++ b/src/khd.cpp
@@ -30,6 +30,8 @@ hotkey Modifiers = {};
 long long ModifierTriggerTime;
 double ModifierTriggerTimeout;
 
+bool ModifierTriggerLast;
+
 internal inline void
 Error(const char *Format, ...)
 {
@@ -74,6 +76,8 @@ KeyCallback(CGEventTapProxy Proxy, CGEventType Type, CGEventRef Event, void *Con
         {
             CGEventFlags Flags = CGEventGetFlags(Event);
             CGKeyCode Key = CGEventGetIntegerValueField(Event, kCGKeyboardEventKeycode);
+
+            ModifierTriggerLast = false;
 
             hotkey *Hotkey = NULL;
             if(HotkeyForCGEvent(Flags, Key, &Hotkey, true))


### PR DESCRIPTION
Improves the behaviour of #21.

~~Modifier only hotkeys will execute if it's the only key that was pressed when it is released again.
This won't work for hotkeys that use multiple modifiers, but eliminates false negatives/positives for a single modifier. The timeout approach also still works.~~

Invalidates modifier only hotkeys when a regular key is pressed making them more reliable with a higher timeout value.